### PR TITLE
metabox 0.1.2

### DIFF
--- a/src/documents-spmeta2/dev-ncrunch.metabox.yaml
+++ b/src/documents-spmeta2/dev-ncrunch.metabox.yaml
@@ -1,0 +1,83 @@
+Metabox:
+  Description: "Revision for NCrunch installation for VS2013/2015 for SPMeta2 related development"
+  Resources:
+    
+    ncrunch-2013:
+      Type: "vagrant::revision"
+      Name: "ncrunch-2013"
+      Tags: [ 'revision' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs13" ]
+
+      VagrantTemplate:
+        - Type: "metabox::vagrant::shell"
+          Tags: [ "revision", "ncrunch-2013" ]
+          Name: "ncrunch-2013"
+          Properties:
+            path: "./scripts/ncrunch/ncrunch_plugin.ps1"
+            env: 
+              - "NCRUNCH_PLUGIN_NAME=ncrunch-vs2013"
+              - "NCRUNCH_PLUGIN_VERSION=3.2.3"
+
+    ncrunch-2015:
+      Type: "vagrant::revision"
+      Name: "ncrunch-2015"
+      Tags: [ 'revision' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs15" ]
+
+      VagrantTemplate:
+        - Type: "metabox::vagrant::shell"
+          Tags: [ "revision", "ncrunch-2015" ]
+          Name: "ncrunch-2015"
+          Properties:
+            path: "./scripts/ncrunch/ncrunch_plugin.ps1"
+            env: 
+              - "NCRUNCH_PLUGIN_NAME=ncrunch-vs2015"
+              - "NCRUNCH_PLUGIN_VERSION=3.2.3"
+
+    ncrunch-grid-server-12:
+        Type: "vagrant::revision"
+        Name: "ncrunch-gridnodeserver"
+        Tags: [ 'revision' ]
+        
+        TargetResource:
+          - MatchType : "tag"
+            Values    : [ "vs13", "vs15", "sp", "sp13", "sp16" ]
+
+        VagrantTemplate:
+          - Type: "metabox::vagrant::shell"
+            Name: "ncrunch-gridnodeserver"
+            Tags: [ "revision", "ncrunch-gridnodeserver" ]
+            Properties:
+              path: "./scripts/ncrunch/ncrunch_gridnode_server.ps1"
+              env: 
+                - "NCRUNCH_GRIDNODE_VERSION=3.2.3"
+                - "NCRUNCH_GRIDNODE_USER_NAME=meta12\\vagrant"
+                - "NCRUNCH_GRIDNODE_USER_PASSWORD=vagrant"
+    
+    ncrunch-grid-server-16:
+        Type: "vagrant::revision"
+        Name: "ncrunch-gridnodeserver"
+        Tags: [ 'revision' ]
+        
+        TargetResource:
+          - MatchType : "tag"
+            Values    : [ "vs13", "vs15", "sp", "sp13", "sp16" ]
+
+        VagrantTemplate:
+          - Type: "metabox::vagrant::shell"
+            Name: "ncrunch-gridnodeserver"
+            Tags: [ "revision", "ncrunch-gridnodeserver" ]
+            Properties:
+              path: "./scripts/ncrunch/ncrunch_gridnode_server.ps1"
+              env: 
+                - "NCRUNCH_GRIDNODE_VERSION=3.2.3"
+                - "NCRUNCH_GRIDNODE_USER_NAME=meta16\\vagrant"
+                - "NCRUNCH_GRIDNODE_USER_PASSWORD=vagrant"
+
+  

--- a/src/documents-spmeta2/dev-tooling.metabox.yaml
+++ b/src/documents-spmeta2/dev-tooling.metabox.yaml
@@ -1,0 +1,19 @@
+Metabox:
+  Description: "Revisions for contoso stack, deploys development tooling to 'vs13' tagged VMs"
+  Resources:
+    
+    dev-tooling:
+      Type: "vagrant::revision"
+      Name: "dev-tooling"
+      Tags: [ 'revision' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs13" ]
+
+      VagrantTemplate:
+        - Type: "metabox::vagrant::shell"
+          Tags: [ "revision", "dev-tooling" ]
+          Name: "Revision dev-tooling"
+          Properties:
+            path: "./scripts/dev-tooling/dev-tools.dsc.ps1"

--- a/src/documents-spmeta2/dev-vs13.metabox.yaml
+++ b/src/documents-spmeta2/dev-vs13.metabox.yaml
@@ -1,0 +1,49 @@
+Metabox:
+  Description: "Revisions for contoso stack, deploys VS2013 to SP-tagged VMs"
+  Resources:
+    
+    vs2013-bin:
+      Type: "vagrant::revision"
+      Name: "vs2013-bin"
+      Tags: [ 'revision', 'vs13_bin' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs13" ]
+
+      VagrantTemplate:
+        # transfer VS binary files
+        - Type: "metabox::vagrant::shell"
+          Name: "vs13 install media"
+          Tags: [ "vs13_bin" ]
+          Properties:
+            path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+            env: 
+              - "METABOX_RESOURCE_NAME=vs2013.5_ent_enu"
+
+    vs2013-install:
+      Type: "vagrant::revision"
+      Name: "vs2013-install"
+      Tags: [ 'revision', 'vs13_install' ]
+      
+      TargetResource:
+        - MatchType :  "name"
+          Values    : [ "*" ]
+        
+        - MatchType : "tag"
+          Values    : [ "vs13" ]
+
+      VagrantTemplate:
+        # deploy VS
+        - Type: "metabox::vagrant::visual_studio13"
+          Name: "vs13 install"
+          Tags: [ "vs13_install" ]
+          Properties:
+            vs_domain_user_name: "meta12\\vagrant"
+            vs_domain_user_password: "vagrant"
+            
+            dsc_check: "1"
+
+            execute_tests: true
+            vs_test_product_name: "Microsoft Visual Studio Ultimate 2013 with Update 5"
+            vs_test_officetools_package_name: "Microsoft Office Developer Tools for Visual Studio"

--- a/src/documents-spmeta2/dev-vs15.metabox.yaml
+++ b/src/documents-spmeta2/dev-vs15.metabox.yaml
@@ -1,0 +1,50 @@
+Metabox:
+  Description: "Revisions for contoso stack, deploys VS2013 to SP-tagged VMs"
+  Resources:
+    
+    vs2015-bin:
+      Type: "vagrant::revision"
+      Name: "vs2015-bin"
+      Tags: [ 'revision', 'vs15_bin' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs15" ]
+
+      VagrantTemplate:
+        # transfer VS binary files
+        - Type: "metabox::vagrant::shell"
+          Name: "vs15 install media"
+          Tags: [ "vs15_bin" ]
+          Properties:
+            path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+            env: 
+              - "METABOX_RESOURCE_NAME=vs2015.3_ent_enu"
+
+    vs2015-install:
+      Type: "vagrant::revision"
+      Name: "vs2015-install"
+      Tags: [ 'revision', 'vs15_install' ]
+      
+      TargetResource:
+        - MatchType : "tag"
+          Values    : [ "vs15" ]
+
+      VagrantTemplate:
+        # deploy VS
+        - Type: "metabox::vagrant::visual_studio13"
+          Name: "vs15 install"
+          Tags: [ "vs15_install" ]
+          Properties:
+            vs_domain_user_name: "meta16\\vagrant"
+            vs_domain_user_password: "vagrant"
+            vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu"
+            vs_product_name: "Microsoft Visual Studio Enterprise 2015 with Update 3"
+            
+            # VS15 woudn't give desired state over DSC check
+            # TODO to troubleshoot
+            #dsc_check: "1"
+
+            execute_tests: true
+            vs_test_product_name: "Microsoft Visual Studio Enterprise 2015 with Updates"
+            vs_test_officetools_package_name: "Microsoft Office Developer Tools for Visual Studio 2015"

--- a/src/documents-spmeta2/scripts/dev-tooling/dev-tools.dsc.ps1
+++ b/src/documents-spmeta2/scripts/dev-tooling/dev-tools.dsc.ps1
@@ -1,0 +1,86 @@
+# fail on errors and include metabox helpers
+$ErrorActionPreference = "Stop"
+
+$metaboxCoreScript = "c:/Windows/Temp/_metabox_core.ps1"
+if(Test-Path $metaboxCoreScript) { . $metaboxCoreScript } else { throw "Cannot find core script: $metaboxCoreScript"}
+
+Log-MbInfoMessage "Installing additional development software..."
+Trace-MbEnv
+
+Configuration Install_DevelopmentSoftware
+{
+    Import-DscResource -Module CChoco
+   
+    Node localhost
+    { 
+        cChocoPackageInstaller 7zip
+        {
+            Name                 = '7zip'
+            Ensure               = 'Present'
+        }
+
+        cChocoPackageInstaller ilspy
+        {
+            Name                 = 'ilspy'
+            Ensure               = 'Present'
+        }
+
+        cChocoPackageInstaller ulsviewer
+        {
+            Name                 = 'ulsviewer'
+            Ensure               = 'Present'   
+        }
+
+        cChocoPackageInstaller sharepointmanager2013
+        {
+            Name                 = 'sharepointmanager2013'
+            Ensure               = 'Present'   
+        }
+
+        cChocoPackageInstaller googlechrome
+        {
+            Name                 = 'googlechrome'
+            Ensure               = 'Present'   
+        }
+
+        cChocoPackageInstaller firefox
+        {
+            Name                 = 'firefox'
+            Ensure               = 'Present'   
+        }
+
+        cChocoPackageInstaller git
+        {
+            Name                 = 'git'
+            Ensure               = 'Present'   
+        }
+    
+        cChocoPackageInstaller visualstudiocode
+        {
+            Name                 = 'visualstudiocode'
+            Ensure               = 'Present'   
+        }
+       
+        cChocoPackageInstaller cmder
+        {
+            Name                 = 'cmder'
+            Ensure               = 'Present'   
+        }
+    }
+}
+
+# dsc config
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            RetryCount = 10           
+            RetryIntervalSec = 30
+        }
+    )
+}
+
+Apply-MbDSC "Install_DevelopmentSoftware" $config 
+
+exit 0

--- a/src/documents-spmeta2/scripts/ncrunch/ncrunch_gridnode_server.ps1
+++ b/src/documents-spmeta2/scripts/ncrunch/ncrunch_gridnode_server.ps1
@@ -1,0 +1,89 @@
+# fail on errors and include metabox helpers
+$ErrorActionPreference = "Stop"
+
+$metaboxCoreScript = "c:/Windows/Temp/_metabox_core.ps1"
+if(Test-Path $metaboxCoreScript) { . $metaboxCoreScript } else { throw "Cannot find core script: $metaboxCoreScript"}
+
+Log-MbInfoMessage "Running NCrunch Grid Node Server configuration..."
+Trace-MbEnv
+
+$packageVersion      = Get-MbEnvVariable "NCRUNCH_GRIDNODE_VERSION"
+$domainUserName      = Get-MbEnvVariable "NCRUNCH_GRIDNODE_USER_NAME"
+$domainUserPassword  = Get-MbEnvVariable "NCRUNCH_GRIDNODE_USER_PASSWORD"
+
+$securePassword = ConvertTo-SecureString $domainUserPassword -AsPlainText -Force
+$domainUserCreds = New-Object System.Management.Automation.PSCredential($domainUserName, $securePassword)
+
+Configuration Install_NCrunchGridNodeServer
+{
+    Import-DscResource -Module CChoco
+   
+    Node localhost
+    { 
+        cChocoPackageInstaller NCrunchGrid
+        {
+            Name                 = 'ncrunch-gridnodeserver'
+            Ensure               = 'Present'
+            AutoUpgrade          = $false
+            Version              = $Node.PackageVersion
+        }
+
+        File NCrunchGridWorkingFolder {
+            DependsOn       = "[cChocoPackageInstaller]NCrunchGrid"
+            Type            = 'Directory'
+            DestinationPath = 'C:\_ncrunch'
+            Ensure          = "Present"
+        }
+
+        Registry NCrunchGridRegPassword {
+            DependsOn   = "[File]NCrunchGridWorkingFolder"
+            Ensure      = "Present"
+            Key         = "HKLM:\SOFTWARE\Remco Software\NCrunch Grid Node"
+            ValueName   = "Password"
+            ValueData   = "l1baZf5Srvt2UfUmYpuaBM9hGRcsqjv+An/SokCfzk8="
+            ValueType   = "String" 
+        }
+
+        Registry NCrunchGridRegWorkingDir {
+            DependsOn   = "[File]NCrunchGridWorkingFolder"
+            Ensure      = "Present"
+            Key         = "HKLM:\SOFTWARE\Remco Software\NCrunch Grid Node"
+            ValueName   = "SnapshotStorageDirectory"
+            ValueData   = "C:\_ncrunch"
+            ValueType   = "String" 
+        }
+
+        Service NCrunchGridService
+        {
+            DependsOn       = "[Registry]NCrunchGridRegPassword", "[Registry]NCrunchGridRegWorkingDir"
+            
+            Name            = "NCrunchGridNode"
+            StartupType     = "Automatic"
+            State           = "Running"
+
+            Credential      = $domainUserCreds
+        }      
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+
+            PSDscAllowPlainTextPassword = $true
+            PSDscAllowDomainUser = $true
+            
+            RetryCount = 10           
+            RetryIntervalSec = 30
+
+            PackageVersion  = $packageVersion
+        }
+    )
+}
+
+# install grid node server
+Log-MbInfoMessage "Installing grid node server..."
+Apply-MbDSC "Install_NCrunchGridNodeServer" $config 
+
+exit 0

--- a/src/documents-spmeta2/scripts/ncrunch/ncrunch_plugin.ps1
+++ b/src/documents-spmeta2/scripts/ncrunch/ncrunch_plugin.ps1
@@ -1,0 +1,47 @@
+# fail on errors and include metabox helpers
+$ErrorActionPreference = "Stop"
+
+$metaboxCoreScript = "c:/Windows/Temp/_metabox_core.ps1"
+if(Test-Path $metaboxCoreScript) { . $metaboxCoreScript } else { throw "Cannot find core script: $metaboxCoreScript"}
+
+Log-MbInfoMessage "Running NCrunch Grid Node configuration..."
+Trace-MbEnv
+
+$packageName     = Get-MbEnvVariable "METABOX_NCRUNCH_PLUGIN_NAME"
+$packageVersion  = Get-MbEnvVariable "METABOX_NCRUNCH_PLUGIN_VERSION"
+
+Configuration Install_NCrunchPlugin
+{
+    Import-DscResource -Module CChoco
+   
+    Node localhost
+    { 
+        cChocoPackageInstaller NCrunchVs
+        {
+            Name                 = $Node.PackageName
+            Ensure               = 'Present'
+            AutoUpgrade          = $false
+            Version              = $Node.PackageVersion
+        }        
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+
+            PSDscAllowPlainTextPassword = $true
+            
+            RetryCount       = 10           
+            RetryIntervalSec = 30
+
+            PackageName     = $packageName
+            PackageVersion  = $packageVersion
+        }
+    )
+}
+
+Apply-MbDSC "Install_NCrunchPlugin" $config 
+
+exit 0

--- a/src/documents-spmeta2/spmeta2-2012r2.metabox.yaml
+++ b/src/documents-spmeta2/spmeta2-2012r2.metabox.yaml
@@ -1,0 +1,257 @@
+Metabox:
+  Description: Complete development stack for SPMeta2 development on Windows 2012R2. Creates two VMs - (1) DC (2) SQL + SharePoint 2013 SP1
+  Parameters:
+    box_app:     "win2012-r2-mb-app-${ENV:METABOX_GIT_BRANCH}"
+    box_sp:      "win2012-r2-mb-bin-sp13-${ENV:METABOX_GIT_BRANCH}"
+   
+    machine_folder_dc : "${ENV:METABOX_SPMETA_MACHINE_FOLDER_DC}/${ENV:METABOX_GIT_BRANCH}"
+    machine_folder_sql: "${ENV:METABOX_SPMETA_MACHINE_FOLDER_SQL}/${ENV:METABOX_GIT_BRANCH}"
+    machine_folder_dev: "${ENV:METABOX_SPMETA_MACHINE_FOLDER_DEV}/${ENV:METABOX_GIT_BRANCH}"
+  Resources:
+    
+    spmeta2-2012r2:
+      Type: "vagrant::stack"
+      Parameters:
+        app_box_name:       "Fn::GetParameter box_app"
+        sp_box_name:        "Fn::GetParameter box_sp"
+        
+        dc_domain_name:           "meta12.local"
+        dc_domain_admin_name:     "admin"
+        dc_domain_admin_password: "u8wxvKQ2zn"
+
+        # SQL specific params
+        sql12_bin_path: "c:\\_metabox_resources\\sql2012sp2"
+        
+        sql_instance_name:        "MSSQLSERVER"
+        sql_instance_features:    "SQLENGINE,SSMS,ADV_SSMS"
+       
+        # SharePoint specific settings
+        sp_setup_user_name:     "meta12\\vagrant"
+        sp_setup_user_password: "vagrant"
+
+      Resources:
+        # deploys DC controller
+        dc:
+          Tags: [ "dc" ]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter app_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 2
+                memory: 512
+                machinefolder: "Fn::GetParameter machine_folder_dc"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                  hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+        
+            - Type: "metabox::vagrant::dc12"
+              Name: "DC configuration"
+              Tags: [ "dc" ]
+              Properties:
+                execute_tests: true
+              
+                dc_domain_name          : "Fn::GetParameter dc_domain_name"
+                dc_domain_admin_name    : "Fn::GetParameter dc_domain_admin_name"
+                dc_domain_admin_password: "Fn::GetParameter dc_domain_admin_password"
+   
+        # deploys SQL12 server
+        # this one is used only with dev VMs for regression testing scenario
+        # use dev-loval VMs for local development
+        sql12:
+          Tags: ["sql12"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter app_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 6144
+                machinefolder: "Fn::GetParameter machine_folder_sql"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+            
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # transfer files
+            - Type: "metabox::vagrant::shell"
+              Tags: [ "sql_bin" ]
+              Properties:
+                path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+                env: 
+                  - "METABOX_RESOURCE_NAME=sql2012sp2"
+            
+            # provision SQL
+            - Type: "metabox::vagrant::sql12"
+              Tags: [ "sql_install" ]
+              Properties:
+                execute_tests: true
+
+                # SQL specific params
+                sql_bin_path:           "Fn::GetParameter sql12_bin_path"
+                sql_instance_name:      "Fn::GetParameter sql_instance_name"
+                sql_instance_features:  "Fn::GetParameter sql_instance_features"
+                sql_sys_admin_accounts:
+                  - "vagrant"
+                  - "meta12\\vagrant"
+                dsc_check: "1"
+
+        # deploys a developer machine with SQL Server, SharePoint 2013 SP1 and VS2013
+        # in that case, no shared SQL is used, all setup happens on the same VM
+        # we use this for a local development
+        "dev-local${ENV:METABOX_SPMETA_VM_NAME}":
+          Tags: ["dev", "vs13", "vs15"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter sp_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 10240
+                machinefolder: "Fn::GetParameter machine_folder_dev"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # transfer files
+            - Type: "metabox::vagrant::shell"
+              Tags: [ "sql_bin" ]
+              Properties:
+                path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+                env: 
+                  - "METABOX_RESOURCE_NAME=sql2012sp2"
+            
+            # provision SQL
+            - Type: "metabox::vagrant::sql12"
+              Tags: [ "sql_install" ]
+              Properties:
+                execute_tests: true
+
+                # SQL specific params
+                sql_bin_path:           "Fn::GetParameter sql12_bin_path"
+                sql_instance_name:      "Fn::GetParameter sql_instance_name"
+                sql_instance_features:  "Fn::GetParameter sql_instance_features"
+                sql_sys_admin_accounts:
+                  - "vagrant"
+                  - "meta12\\vagrant"
+                dsc_check: "1"
+
+            # installs SharePoint 2013
+            - Type: "metabox::vagrant::sharepoint"
+              Name: "sharepoint install"
+              Tags: [ "sp_install" ]
+              Properties:
+                execute_tests: true
+
+                # sharepoint specific settings
+                sp_version: "sp2013"
+                sp_role   : ["wfe"]
+
+                # SQL point to the local VM, use GetHostName here
+                sp_farm_sql_server_host_name: "Fn::GetResourceHostName dev-local${ENV:METABOX_SPMETA_VM_NAME}"
+                sp_farm_sql_db_prefix: "Fn::GetResourceName"
+                
+                sp_farm_passphrase: "Fn::GetParameter dc_domain_admin_password"
+
+                sp_setup_user_name: "Fn::GetParameter sp_setup_user_name"
+                sp_setup_user_password: "Fn::GetParameter sp_setup_user_password"
+
+        # deploys a developer machine with SharePoint 2013 SP1 and VS2013
+        # SQL server is meant to be shared, sql12
+        # this is a regression testing scenario for SPMeta2
+        # we use this to spin up a grid of dozen farm with NCrunch Grid Node
+        # SQL is shared, 6G is ok, and then every SP farm has 6G as well
+        "dev${ENV:METABOX_SPMETA_VM_NAME}":
+          Tags: ["dev", "vs13", "vs15"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter sp_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 6144
+                machinefolder: "Fn::GetParameter machine_folder_dev"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # installs SharePoint 2013
+            - Type: "metabox::vagrant::sharepoint"
+              Name: "sharepoint install"
+              Tags: [ "sp_install" ]
+              Properties:
+                execute_tests: true
+
+                # sharepoint specific settings
+                sp_version: "sp2013"
+                sp_role   : ["wfe"]
+
+                sp_farm_sql_server_host_name: "Fn::GetResourceHostName sql12"
+                sp_farm_sql_db_prefix: "Fn::GetResourceName"
+                
+                sp_farm_passphrase: "Fn::GetParameter dc_domain_admin_password"
+
+                sp_setup_user_name: "Fn::GetParameter sp_setup_user_name"
+                sp_setup_user_password: "Fn::GetParameter sp_setup_user_password"

--- a/src/documents-spmeta2/spmeta2-2016.metabox.yaml
+++ b/src/documents-spmeta2/spmeta2-2016.metabox.yaml
@@ -1,0 +1,259 @@
+Metabox:
+  Description: Complete development stack for SPMeta2 development on Windows 2016. Creates two VMs - (1) DC (2) SQL + SharePoint 2016 Feature Pack 2
+  Parameters:
+    box_app:     "win2016-mb-app-${ENV:METABOX_GIT_BRANCH}"
+    #box_sp:      "win2016-mb-bin-sp16fp2-${ENV:METABOX_GIT_BRANCH}"
+    box_sp:      "win2016-mb-bin-sp16fp2-sp16fp2"
+   
+    machine_folder_dc : "${ENV:METABOX_SPMETA_MACHINE_FOLDER_DC}/${ENV:METABOX_GIT_BRANCH}"
+    machine_folder_sql: "${ENV:METABOX_SPMETA_MACHINE_FOLDER_SQL}/${ENV:METABOX_GIT_BRANCH}"
+    machine_folder_dev: "${ENV:METABOX_SPMETA_MACHINE_FOLDER_DEV}/${ENV:METABOX_GIT_BRANCH}"
+  Resources:
+    
+    spmeta2-2016:
+      Type: "vagrant::stack"
+      Parameters:
+        app_box_name:       "Fn::GetParameter box_app"
+        sp_box_name:        "Fn::GetParameter box_sp"
+        
+        dc_domain_name:           "meta16.local"
+        dc_domain_admin_name:     "admin"
+        dc_domain_admin_password: "u8wxvKQ2zn"
+
+        # SQL specific params
+        sql14_bin_path: "c:\\_metabox_resources\\sql2014sp1"
+        
+        sql_instance_name:        "MSSQLSERVER"
+        sql_instance_features:    "SQLENGINE,SSMS,ADV_SSMS"
+       
+        # SharePoint specific settings
+        sp_setup_user_name:     "meta16\\vagrant"
+        sp_setup_user_password: "vagrant"
+
+      Resources:
+        # deploys DC controller
+        dc:
+          Tags: [ "dc" ]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter app_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 2
+                memory: 1024
+                machinefolder: "Fn::GetParameter machine_folder_dc"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                  hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+        
+            - Type: "metabox::vagrant::dc12"
+              Name: "DC configuration"
+              Tags: [ "dc" ]
+              Properties:
+                execute_tests: true
+              
+                dc_domain_name          : "Fn::GetParameter dc_domain_name"
+                dc_domain_admin_name    : "Fn::GetParameter dc_domain_admin_name"
+                dc_domain_admin_password: "Fn::GetParameter dc_domain_admin_password"
+   
+        # deploys SQL12 server
+        # this one is used only with dev VMs for regression testing scenario
+        # use dev-loval VMs for local development
+        sql14:
+          Tags: ["sql14"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter app_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 6144
+                machinefolder: "Fn::GetParameter machine_folder_sql"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+            
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # transfer files
+            - Type: "metabox::vagrant::shell"
+              Tags: [ "sql_bin" ]
+              Properties:
+                path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+                env: 
+                  - "METABOX_RESOURCE_NAME=sql2014sp1"
+            
+            # provision SQL
+            - Type: "metabox::vagrant::sql12"
+              Tags: [ "sql_install" ]
+              Properties:
+                execute_tests: true
+
+                # SQL specific params
+                sql_bin_path:           "Fn::GetParameter sql14_bin_path"
+                sql_instance_name:      "Fn::GetParameter sql_instance_name"
+                sql_instance_features:  "Fn::GetParameter sql_instance_features"
+                sql_sys_admin_accounts:
+                  - "vagrant"
+                  - "meta16\\vagrant"
+                dsc_check: "1"
+
+        # deploys a developer machine with SQL Server, SharePoint 2013 SP1 and VS2013
+        # in that case, no shared SQL is used, all setup happens on the same VM
+        # we use this for a local development
+        "dev-local${ENV:METABOX_SPMETA_VM_NAME}":
+          Tags: ["dev", "vs13", "vs15"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter sp_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 10240
+                #memory: 6000
+                machinefolder: "Fn::GetParameter machine_folder_dev"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # transfer files
+            - Type: "metabox::vagrant::shell"
+              Tags: [ "sql_bin" ]
+              Properties:
+                path: "./scripts/packer/metabox.packer.core/_metabox_dist_helper.ps1"
+                env: 
+                  - "METABOX_RESOURCE_NAME=sql2014sp1"
+            
+            # provision SQL
+            - Type: "metabox::vagrant::sql12"
+              Tags: [ "sql_install" ]
+              Properties:
+                execute_tests: true
+
+                # SQL specific params
+                sql_bin_path:           "Fn::GetParameter sql14_bin_path"
+                sql_instance_name:      "Fn::GetParameter sql_instance_name"
+                sql_instance_features:  "Fn::GetParameter sql_instance_features"
+                sql_sys_admin_accounts:
+                  - "vagrant"
+                  - "meta16\\vagrant"
+                dsc_check: "1"
+
+            # installs SharePoint 2013
+            - Type: "metabox::vagrant::sharepoint"
+              Name: "sharepoint install"
+              Tags: [ "sp_install" ]
+              Properties:
+                execute_tests: true
+
+                # sharepoint specific settings
+                sp_version: "sp2016"
+                sp_role   : ["wfe"]
+
+                # SQL point to the local VM, use GetHostName here
+                sp_farm_sql_server_host_name: "Fn::GetResourceHostName dev-local${ENV:METABOX_SPMETA_VM_NAME}"
+                sp_farm_sql_db_prefix: "Fn::GetResourceName"
+                
+                sp_farm_passphrase: "Fn::GetParameter dc_domain_admin_password"
+
+                sp_setup_user_name: "Fn::GetParameter sp_setup_user_name"
+                sp_setup_user_password: "Fn::GetParameter sp_setup_user_password"
+
+        # deploys a developer machine with SharePoint 2013 SP1 and VS2013
+        # SQL server is meant to be shared, sql12
+        # this is a regression testing scenario for SPMeta2
+        # we use this to spin up a grid of dozen farm with NCrunch Grid Node
+        # SQL is shared, 6G is ok, and then every SP farm has 6G as well
+        "dev${ENV:METABOX_SPMETA_VM_NAME}":
+          Tags: ["dev", "vs13", "vs15"]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter sp_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 6144
+                machinefolder: "Fn::GetParameter machine_folder_dev"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+         
+            - Type: "metabox::vagrant::dcjoin"
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name:         "Fn::GetParameter dc_domain_name"
+                dc_join_user_name:      "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password:  "Fn::GetParameter dc_domain_admin_password"
+
+            # installs SharePoint 2013
+            - Type: "metabox::vagrant::sharepoint"
+              Name: "sharepoint install"
+              Tags: [ "sp_install" ]
+              Properties:
+                execute_tests: true
+
+                # sharepoint specific settings
+                sp_version: "sp2016"
+                sp_role   : ["wfe"]
+
+                sp_farm_sql_server_host_name: "Fn::GetResourceHostName sql14"
+                sp_farm_sql_db_prefix: "Fn::GetResourceName"
+                
+                sp_farm_passphrase: "Fn::GetParameter dc_domain_admin_password"
+
+                sp_setup_user_name: "Fn::GetParameter sp_setup_user_name"
+                sp_setup_user_password: "Fn::GetParameter sp_setup_user_password"

--- a/src/documents/contoso/contoso-win2012r2.metabox.yaml
+++ b/src/documents/contoso/contoso-win2012r2.metabox.yaml
@@ -1,10 +1,9 @@
 Metabox:
   Description: Contoso stack with DC, client, SQL, VS and SharePoint
   Parameters:
-    box_soe:     "win2012-r2-mb-soe-${ENV:METABOX_GIT_BRANCH}"
     box_app:     "win2012-r2-mb-app-${ENV:METABOX_GIT_BRANCH}"
     box_sp:      "win2012-r2-mb-bin-sp13-${ENV:METABOX_GIT_BRANCH}"
-    #box_sp16:   "win2016-mb-bin-sp16fp2-${ENV:METABOX_GIT_BRANCH}"
+  
     box_sp16:    "win2016-mb-bin-sp16-${ENV:METABOX_GIT_BRANCH}"
     box_sp16fp2: "win2016-mb-bin-sp16fp2-${ENV:METABOX_GIT_BRANCH}"
 
@@ -14,7 +13,6 @@ Metabox:
     contoso-win2012-r2:
       Type: "vagrant::stack"
       Parameters:
-        soe_box_name:       "Fn::GetParameter box_soe"
         app_box_name:       "Fn::GetParameter box_app"
         sp_box_name:        "Fn::GetParameter box_sp"
         sp16_box_name:      "Fn::GetParameter box_sp16"
@@ -69,6 +67,55 @@ Metabox:
               Tags: [ "dc" ]
               Properties:
                 execute_tests: true
+              
+                dc_domain_name: "Fn::GetParameter dc_domain_name"
+                dc_domain_admin_name: "Fn::GetParameter dc_domain_admin_name"
+                dc_domain_admin_password: "Fn::GetParameter dc_domain_admin_password"
+
+        dc-replica:
+          Tags: [ "dc-replica" ]
+          VagrantTemplate:
+            - Type: "vagrant::config::vm"
+              Properties:
+                box: "Fn::GetParameter app_box_name"
+
+            - Type: "vagrant::config::vm::provider::virtualbox"
+              Properties:
+                cpus: 4
+                memory: 1024
+                machinefolder: "Fn::GetParameter custom_machine_folder"
+
+            - Type: "metabox::vagrant::host"
+              Properties:
+                  hostname: "Fn::GetHostName"
+
+            - Type: "metabox::vagrant::win12soe"
+              Name: "SOE config"
+              Tags: [ "soe" ]
+              Properties:
+                execute_tests: true
+
+            # join VM to domain
+            - Type: "metabox::vagrant::dcjoin"
+              Name: "dc join"
+              Tags: [ "dc-join" ]
+              Properties:
+                execute_tests: true
+
+                # dc specific parameters
+                dc_domain_name: "Fn::GetParameter dc_domain_name"
+                dc_join_user_name: "Fn::GetParameter dc_domain_admin_name"
+                dc_join_user_password: "Fn::GetParameter dc_domain_admin_password"
+
+            # create a replica with
+            # - type: "replica"
+            - Type: "metabox::vagrant::dc12"
+              Name: "Replica dc configuration"
+              Tags: [ "dc-replica" ]
+              Properties:
+                type: "replica"
+
+                #execute_tests: true
               
                 dc_domain_name: "Fn::GetParameter dc_domain_name"
                 dc_domain_admin_name: "Fn::GetParameter dc_domain_admin_name"
@@ -214,7 +261,7 @@ Metabox:
               Properties:
                 vs_domain_user_name: "soe-win2012-r2\\vagrant"
                 vs_domain_user_password: "vagrant"
-                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu\\vs_enterprise.exe"
+                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu"
                 vs_product_name: "Microsoft Visual Studio Enterprise 2015 with Update 3"
                 
                 # VS15 woudn't give desired state over DSC check
@@ -398,7 +445,8 @@ Metabox:
             - Type: "vagrant::config::vm::provider::virtualbox"
               Properties:
                 cpus: 4
-                memory: 4096
+                memory: 6144
+                #memory: 4096
                 machinefolder: "Fn::GetParameter custom_machine_folder"
 
             - Type: "metabox::vagrant::host"

--- a/src/documents/contoso_revisions/ncrunch.metabox.yaml
+++ b/src/documents/contoso_revisions/ncrunch.metabox.yaml
@@ -17,7 +17,7 @@ Metabox:
       VagrantTemplate:
         - Type: "metabox::vagrant::shell"
           Tags: [ "revision", "ncrunch-2013" ]
-          Name: "Revision ncrunch-2013"
+          Name: "ncrunch-2013"
           Properties:
             path: "./scripts/ncrunch/ncrunch_plugin.ps1"
             env: 
@@ -38,7 +38,7 @@ Metabox:
 
         VagrantTemplate:
           - Type: "metabox::vagrant::shell"
-            Name: "Revision ncrunch-gridnodeserver"
+            Name: "ncrunch-gridnodeserver"
             Tags: [ "revision", "ncrunch-gridnodeserver" ]
             Properties:
               path: "./scripts/ncrunch/ncrunch_gridnode_server.ps1"

--- a/src/documents/metabox_ci/scripts/jenkins2/metabox-ci.ps1
+++ b/src/documents/metabox_ci/scripts/jenkins2/metabox-ci.ps1
@@ -338,7 +338,6 @@ function Mb-InitSlave {
         Init-SlaveMac     $portNumber $slaveName
     }
 }
-
 function Mb-RestartSlave {
     Param(
         [Parameter(Mandatory=$True)]

--- a/src/documents/metabox_ci/scripts/vagrant/centos7-mb-jenkins2/pipelines/metabox/vagrant-stacks/contoso-win2012-r2/up-sql12.groovy
+++ b/src/documents/metabox_ci/scripts/vagrant/centos7-mb-jenkins2/pipelines/metabox/vagrant-stacks/contoso-win2012-r2/up-sql12.groovy
@@ -1,0 +1,12 @@
+node("metabox") {
+
+    // metabox system init - start
+    def mbSrcPath           = env.METABOX_SRC_PATH == null ? "src" : env.METABOX_SRC_PATH;
+    def mbVagrantBuildPath  = env.METABOX_VAGRANT_BUILD_DIR 
+    def mbUtils             = load "$mbVagrantBuildPath/scripts/vagrant/centos7-mb-jenkins2/pipelines_shared/metabox-utils.groovy"
+    // metabox system init - end
+    
+    mbUtils.runMetaboxPrepareStages(mbSrcPath);
+
+    mbUtils.runMetaboxVagrantStackVMUp(mbSrcPath);
+}

--- a/src/documents/metabox_downloads/metabox-KBs.metabox.yaml
+++ b/src/documents/metabox_downloads/metabox-KBs.metabox.yaml
@@ -26,3 +26,15 @@ Metabox:
               Enabled: true
               Type: "sha1"
               Value: "f97d8290d9d75d96f163095c4cb05e1b9f6986e0" 
+
+        # .NET 4.6
+        # choco install dotnet4.6
+        KB3045557:
+          Type: "metabox::http::file"
+          Properties:
+            SourceUrl: "http://download.microsoft.com/download/C/3/A/C3A5200B-D33C-47E9-9D70-2F7C65DAAD94/NDP46-KB3045557-x86-x64-AllOS-ENU.exe"
+            DestinationPath: "${ENV:METABOX_DOWNLOADS_PATH}/KB3045557/NDP46-KB3045557-x86-x64-AllOS-ENU.exe"
+            Checksum:
+              Enabled: true
+              Type: "sha1"
+              Value: "3049a85843eaf65e89e2336d5fe6e85e416797be" 

--- a/src/documents/metabox_images_soe_app/win2012-mb-app.metabox.yaml
+++ b/src/documents/metabox_images_soe_app/win2012-mb-app.metabox.yaml
@@ -28,6 +28,12 @@ Metabox:
               source: "./scripts/packer/metabox.packer.core/answer_files/2012/Autounattend_sysprep.xml"
               destination: "c:/Windows/Temp/Autounattend_sysprep.xml"
 
+            # re-ensuring PowerShell modules
+            # that helps to avoid SOE rebuild
+            - type: "powershell"
+              scripts:
+                - "./scripts/packer/metabox.packer.core/_install-dsc-modules.ps1"
+
             # NET core install and reboot
             # two hits with METABOX_DSC_CHECK=1 flag to mitigate glitches
             - type: "powershell"

--- a/src/documents/metabox_images_soe_app/win2012-r2-mb-app.metabox.yaml
+++ b/src/documents/metabox_images_soe_app/win2012-r2-mb-app.metabox.yaml
@@ -28,6 +28,12 @@ Metabox:
               source: "./scripts/packer/metabox.packer.core/answer_files/2012_r2/Autounattend_sysprep.xml"
               destination: "c:/Windows/Temp/Autounattend_sysprep.xml"
 
+            # re-ensuring PowerShell modules
+            # that helps to avoid SOE rebuild
+            - type: "powershell"
+              scripts:
+                - "./scripts/packer/metabox.packer.core/_install-dsc-modules.ps1"
+
             # NET core install and reboot
             # two hits with METABOX_DSC_CHECK=1 flag to mitigate glitches
             # installing it first as it may hang and fail while installing via Internet

--- a/src/documents/metabox_images_soe_app/win2016-mb-app.metabox.yaml
+++ b/src/documents/metabox_images_soe_app/win2016-mb-app.metabox.yaml
@@ -41,6 +41,12 @@ Metabox:
               source: "./scripts/packer/metabox.packer.core/answer_files/2016/Autounattend_sysprep.xml"
               destination: "c:/Autounattend_sysprep.xml"
         
+            # re-ensuring PowerShell modules
+            # that helps to avoid SOE rebuild
+            - type: "powershell"
+              scripts:
+                - "./scripts/packer/metabox.packer.core/_install-dsc-modules.ps1"
+
             # NET core install and reboot
             # two hits with METABOX_DSC_CHECK=1 flag to mitigate glitches
             - type: "powershell"
@@ -53,6 +59,13 @@ Metabox:
                 - "./scripts/packer/metabox.packer.core/_install-netcore-feature.ps1"
               environment_vars:
                 - "METABOX_DSC_CHECK=1"
+
+            # installing additional packages
+            # these will be used to simplify VS setup and installs later on
+            - type: "powershell"
+              inline:
+                - "Write-Host 'Installing Web Platform Installer...'"
+                - "choco install -y webpicmd"
 
             # # This onw won't work correcly
             # # - features get installed incorrectly spoiling prereq/bin SharePoint installs

--- a/src/documents/metabox_regression/regression-win2012-r2.metabox.yaml
+++ b/src/documents/metabox_regression/regression-win2012-r2.metabox.yaml
@@ -207,7 +207,7 @@ Metabox:
               Properties:
                 vs_domain_user_name: "reg-win2012-r2\\vagrant"
                 vs_domain_user_password: "vagrant"
-                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu\\vs_enterprise.exe"
+                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu"
                 vs_product_name: "Microsoft Visual Studio Enterprise 2015 with Update 3"
                 
                 # VS15 woudn't give desired state over DSC check

--- a/src/documents/metabox_regression/regression-win2016.metabox.yaml
+++ b/src/documents/metabox_regression/regression-win2016.metabox.yaml
@@ -209,7 +209,7 @@ Metabox:
               Properties:
                 vs_domain_user_name: "reg-win2016\\vagrant"
                 vs_domain_user_password: "vagrant"
-                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu\\vs_enterprise.exe"
+                vs_executable_path: "c:\\_metabox_resources\\vs2015.3_ent_enu"
                 vs_product_name: "Microsoft Visual Studio Enterprise 2015 with Update 3"
                 
                 # VS15 woudn't give desired state over DSC check

--- a/src/metabox/lib/metabox/version.rb
+++ b/src/metabox/lib/metabox/version.rb
@@ -1,3 +1,3 @@
 module Metabox
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/src/metabox/lib/services/core/environment_service.rb
+++ b/src/metabox/lib/services/core/environment_service.rb
@@ -6,6 +6,8 @@ module Metabox
         @http_server_addr;
         @local_metabox_values;
 
+        @revisions_flag;
+
         def initialize
             @local_metabox_values = {}
         end
@@ -32,8 +34,12 @@ module Metabox
             }
         end
 
-        def get_metabox_variables(raise_on_missing_vars: true)
+        def get_metabox_variables(raise_on_missing_vars: true, exclude_variables: [])
             result = {}
+
+            if exclude_variables.nil?
+                exclude_variables = []
+            end
 
             __env.each { | name, value |
                 if name.upcase.include? "METABOX_"
@@ -48,6 +54,10 @@ module Metabox
             }
 
             _fill_system_vars result, raise_on_missing_vars
+
+            exclude_variables.each do | exclude_variable_name |
+                result.delete(exclude_variable_name)
+            end
 
             result
         end
@@ -228,8 +238,16 @@ module Metabox
             result
         end
 
+        def enable_revisions
+            @revisions_flag = "1"
+        end
+
+        def disable_revisions
+            @revisions_flag = nil
+        end
+
         def metabox_features_revisions?
-            result = __env.fetch('METABOX_FEATURES_REVISIONS', nil)
+            result = __env.fetch('METABOX_FEATURES_REVISIONS', @revisions_flag)
             
             result != nil
         end

--- a/src/metabox/lib/services/core/os_service.rb
+++ b/src/metabox/lib/services/core/os_service.rb
@@ -23,7 +23,7 @@ module Metabox
             cmd
         end
 
-        def run_cmd(cmd:, is_dry_run: false, pwd: nil, silent: false, valid_exit_codes: [0])
+        def run_cmd(cmd:, is_dry_run: false, pwd: nil, silent: false, valid_exit_codes: [0], exclude_variables: nil)
             
             if is_windows?
                 cmd = process_windows_cmd(cmd: cmd)
@@ -33,7 +33,9 @@ module Metabox
                 pwd = env_service.get_metabox_working_dir
             end
 
-            env_vars = env_service.get_metabox_variables
+            env_vars = env_service.get_metabox_variables(
+                exclude_variables: exclude_variables
+            )
 
             metabox_cmds = []
             metabox_masked_cmds = []

--- a/src/metabox/lib/services/packer/packer_configs/packer_config_builder_packer_win2016_sysprep.rb
+++ b/src/metabox/lib/services/packer/packer_configs/packer_config_builder_packer_win2016_sysprep.rb
@@ -18,6 +18,11 @@ module Metabox
                 # https://github.com/hashicorp/packer/issues/2401
                 "headless" => true,
 
+                # 60G by default to support developer VMs with SQL+SP+VS installs
+                # https://www.packer.io/docs/builders/virtualbox-iso.html#disk_size
+                # https://github.com/SubPointSolutions/metabox/issues/19
+                "disk_size" => 61440,
+
                 "guest_additions_mode" => "attach",
                 "guest_os_type" => "Windows2012_64",
 

--- a/src/metabox/lib/services/packer/packer_configs/scripts/metabox.packer.core/_install-dsc-modules.ps1
+++ b/src/metabox/lib/services/packer/packer_configs/scripts/metabox.packer.core/_install-dsc-modules.ps1
@@ -24,20 +24,12 @@ $packages = @(
     @{ Id = "xTimeZone"; Version = "" },
     @{ Id = "xWebAdministration"; Version = "" },
     @{ Id = "xPendingReboot"; Version = "" },
-    @{ Id = "xComputerManagement"; Version = "" }
+    @{ Id = "xComputerManagement"; Version = "" },
+
+    @{ Id = "DSCR_Shortcut"; Version = "" }
 )
 
 Log-MbInfoMessage "Installing DSC modules: $packages"
-
-foreach($package in $packages ) {
-
-    Log-MbInfoMessage "`tinstalling package: $($package.Id) $($package.Version)"
-    
-    if ([System.String]::IsNullOrEmpty($package["Version"]) -eq $true) {
-        Install-Module -Name $package["Id"] -Force;
-    } else {
-        Install-Module -Name $package["Id"] -RequiredVersion $package["Version"] -Force;
-    }
-}
+Install-MbPSModules $packages
 
 exit 0

--- a/src/metabox/lib/services/service_base.rb
+++ b/src/metabox/lib/services/service_base.rb
@@ -157,8 +157,13 @@ module Metabox
             get_service(Metabox::DocumentService)
         end
 
-        def run_cmd(cmd:, silent: false, pwd: nil, valid_exit_codes:[0])
-            os_service.run_cmd(cmd:cmd, silent: silent, pwd: pwd, valid_exit_codes: valid_exit_codes)
+        def run_cmd(cmd:, silent: false, pwd: nil, valid_exit_codes:[0], exclude_variables: nil)
+            os_service.run_cmd(
+                cmd:cmd, 
+                silent: silent, 
+                pwd: pwd, 
+                valid_exit_codes: valid_exit_codes,
+                exclude_variables: exclude_variables)
         end
 
         def create_packer_vars_file(template_name:)

--- a/src/metabox/lib/services/tasks/revision_task_service.rb
+++ b/src/metabox/lib/services/tasks/revision_task_service.rb
@@ -1,0 +1,25 @@
+
+require_relative "task_service_base"
+require 'json'
+
+module Metabox
+
+    class RevisionTaskService < TaskServiceBase
+
+        def name 
+            "metabox::tasks:revision"
+        end
+
+        def rake_alias 
+            "revision"
+        end
+
+        def apply(params)
+            service = get_service_by_name("metabox::tasks:metabox")
+            service.apply_revision(params)
+        end
+
+        
+    end
+
+end

--- a/src/metabox/lib/services/tasks/task_service_base.rb
+++ b/src/metabox/lib/services/tasks/task_service_base.rb
@@ -12,6 +12,25 @@ module Metabox
             "base"
         end
 
+        private 
+
+        def _execute_workflow(tasks:) 
+            all_tasks_count = tasks.count
+            task_flow = " \n - " + (tasks.collect { |t| t[:name] + "#{t[:params]}" }).join("\n - ")
+
+            log.info "  - executing [#{all_tasks_count}] tasks: #{task_flow}"
+
+            tasks.each do | task |
+                current_task_index = (tasks.index(task) + 1)
+            
+                log.info "  - [#{current_task_index}/#{all_tasks_count}] running task #{task[:description]}..."
+               
+                task_service.execute_task(
+                    task_name: task[:name], 
+                    params: task[:params]
+                )
+            end
+        end
     end
 
 end

--- a/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.sql12/tests/sql12.dsc.Tests.ps1
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.sql12/tests/sql12.dsc.Tests.ps1
@@ -1,5 +1,23 @@
+# fail on errors and include metabox helpers
+$ErrorActionPreference = "Stop"
+
+$metaboxCoreScript = "c:/Windows/Temp/_metabox_core.ps1"
+if(Test-Path $metaboxCoreScript) { . $metaboxCoreScript } else { throw "Cannot find core script: $metaboxCoreScript"}
+
+Log-MbInfoMessage "Testing SQL Server setup..."
+Trace-MbEnv
+
+$instanceFeatures = Get-MbEnvVariable "METABOX_SQL_INSTANCE_FEATURES"
+
+# such as SQLENGINE,SSMS,ADV_SSMS
+$instanceFeaturesArray = $instanceFeatures.Split(',')
+
+$checkSQLEngine = $instanceFeaturesArray.Contains("SQLENGINE") -eq $true
+$checkSSMS      = $instanceFeaturesArray.Contains("SSMS") -eq $true
+
 Describe 'SQL Server 2012 minimal configuration' {
 
+    # always test SQL server itself
     Context "SQL Server" {
         
          It 'MSSQL service is running' {
@@ -12,10 +30,15 @@ Describe 'SQL Server 2012 minimal configuration' {
  
      }
 
+    # only if
     Context "SQL Tools" {
        
-        It 'Ssms.exe is installed' {
-            get-command ssms | Should BeLike "*ssms.exe*"
+        It 'ssms.exe is installed' {
+            if($checkSSMS -eq $true)  {
+                 get-command ssms | Should BeLike "*ssms.exe*"
+            } else {
+                Log-MbInfoMessage "Skipping ssms.exe check"
+            }
         }
 
     }

--- a/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.visual_studio13/vs13.dsc.post_deploy.ps1
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.visual_studio13/vs13.dsc.post_deploy.ps1
@@ -10,7 +10,14 @@ Trace-MbEnv
 $productName = Get-MbEnvVariable "METABOX_VS_PRODUCT_NAME"
 
 if ($productName.Contains("2015") -eq $true) {
+
     Log-MbInfoMessage "Detected VS 2015 install. Ensuring additional plugins..."
+
+    # ensuring "choco install -y webpicmd" is here
+    # it should come with APP image but in case we failed or building on old image, install it in the fly
+    Log-MbInfoMessage "Ensuring webpicmd install..."
+    choco install -y webpicmd
+    Validate-MbExitCode $LASTEXITCODE "Cannot run choco install -y webpicmd"
 
     Log-MbInfoMessage "Installing Office Development tools via webpicmd"
     # https://github.com/mszcool/devmachinesetup/blob/master/Install-WindowsMachine.ps1
@@ -19,7 +26,6 @@ if ($productName.Contains("2015") -eq $true) {
     
 } else {
     Log-MbInfoMessage "No post deploy is needed..."
-
 }
 
 Log-MbInfoMessage  "Visual Studio post-deploy script completed."

--- a/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.visual_studio13/vs13.dsc.ps1
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.visual_studio13/vs13.dsc.ps1
@@ -14,6 +14,14 @@ $deploymentFilePath = Get-MbEnvVariable "METABOX_VS_ADMIN_DEPLOYMENT_FILE_PATH"
 $domainUserName = Get-MbEnvVariable "METABOX_VS_DOMAIN_USER_NAME"
 $domainUserPassword = Get-MbEnvVariable "METABOX_VS_DOMAIN_USER_PASSWORD"
 
+# check if $execPath exists
+# the reason is that different VS editions have different EXE files:
+# - vs_ultimate.exe
+# - vs_enterprise.exe
+# if not, them look for .exe file at the top folder in $execPath
+$execPath = Find-MbFileInPath $execPath
+Log-MbInfoMessage "Using VS install file: $execPath"
+
 Configuration Install_VS2013 {
 
     Import-DSCResource -Name MS_xVisualStudio  

--- a/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.win12soe/tests/soe.dsc.modules.Tests.ps1
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/scripts/metabox.vagrant.win12soe/tests/soe.dsc.modules.Tests.ps1
@@ -55,5 +55,9 @@ Describe 'PowerShell DCS' {
             Get-Module -Name Pester -ListAvailable | Should BeLike "Pester"
         }
 
+        # It 'DSCR_Shortcut' {
+        #     Get-Module -Name DSCR_Shortcut -ListAvailable | Should BeLike "DSCR_Shortcut"
+        # }
+
     }
 }

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_base.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_base.rb
@@ -4,8 +4,6 @@ module Metabox
 
         class VagrantConfigBase < ServiceBase
 
-            @config
-
             attr_accessor :environment_config
 
             def initialize()
@@ -120,19 +118,19 @@ module Metabox
 
                 # empty incoming tags were provided
                 if active_tags.empty?
-                    log.warn "[-] skipping [#{provision_name}], no tag match detected"
+                    log.warn "[-] skipping [#{provision_name}], no provision_tags were provided"
                     return false
                 end
 
                 # only if active tags include any of specified in handler
                 tags.each do | tag |
-                    if active_tags.any? { |s| s.casecmp(tag)==0 }  
-                        log.info "[+] running  [#{provision_name}], tag found: #{tags} among #{tags}"
+                    if active_tags.any? { |s| s.casecmp(tag) == 0 }  
+                        log.info "[+] running  [#{provision_name}], tag found: #{tag} among #{active_tags} within #{tags}"
                         return true
                     end
                 end
                 
-                log.warn "[-] skipping [#{provision_name}], no tag match detected"
+                log.warn "[-] skipping [#{provision_name}], no tag match detected - active_tags: #{active_tags} current tags: #{tags}"
                 return false
             end
 

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_custom_shell.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_custom_shell.rb
@@ -62,10 +62,6 @@ module Metabox
                 end
 
                 raise "not implemented yet"
-
-                script_paths.each do | script_path |
-                    run_cmd(cmd: "sh #{script_path}")
-                end
             end
 
             def _execute_inline_scripts(scripts)
@@ -76,8 +72,15 @@ module Metabox
 
                 home_folder = env_service.get_metabox_vagrant_dir
 
+                # we need to exclude VAGRANT_PROVISION_TAGS variable from custom inline script
+                # custom hooks are used to setup/shutdown CI agents
+                # if this variable gets into CI agent, then Vagant will always be run in 'revision' mode
+                # hence, eliminatibg these vars from custom hooks
                 scripts.each do | script |
-                    run_cmd(cmd: "#{script}", pwd: home_folder)
+                    run_cmd(cmd: "#{script}", pwd: home_folder, exclude_variables: [
+                        "METABOX_VAGRANT_PROVISION_TAGS",
+                        "VAGRANT_PROVISION_TAGS"
+                    ])
                 end
             end
 

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_visual_studio13.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_config_visual_studio13.rb
@@ -6,8 +6,6 @@ module Metabox
 
         class VagrantVS13Config < VagrantConfigBase
 
-            @config
-
             def initialize()
 
             end
@@ -26,7 +24,7 @@ module Metabox
                 target_deployment_file = File.join "c:\\_metabox_config\\#{safe_name}", target_file_name
 
                 props = {
-                    'vs_executable_path' => "c:\\_metabox_resources\\vs2013.5_ent_enu\\vs_ultimate.exe",
+                    'vs_executable_path' => "c:\\_metabox_resources\\vs2013.5_ent_enu",
                     'vs_product_name' => "Microsoft Visual Studio Ultimate 2013 with Update 5",
                     'vs_admin_deployment_file_path' => target_deployment_file
                 }

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_dc12_config.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_dc12_config.rb
@@ -26,31 +26,52 @@ module Metabox
                 default_properties = {}
 
                 _safe_merge_hash(default_properties, config.fetch('Properties', {}))               
+
+                dc_type = default_properties.fetch('type', "main")
+
+                case dc_type
+                when "main" 
+                    dc_domain_name = default_properties.fetch('dc_domain_name')
+
+                    # provision DCm, reload
+                    default_properties["dsc_check_skip"] = "1"
+                    domain_env = _get_metabox_env(default_properties)
+
+                    vm_config.vm.provision "shell", path: get_handler_script_path("dc.dsc.ps1"), env: domain_env
+                    vm_config.vm.provision "reload"
+
+                    default_properties["vagrant_user_name"] = dc_domain_name.split('.')[0] + "\\vagrant"
+                    default_properties["vagrant_user_password"] = "vagrant"
                 
-                dc_domain_name = default_properties.fetch('dc_domain_name')
+                    # provision DC users
+                    default_properties.delete("dsc_check_skip")
+                    users_env = _get_metabox_env(default_properties)   
 
-                # provision DCm, reload
-                default_properties["dsc_check_skip"] = "1"
-                domain_env = _get_metabox_env(default_properties)
+                    vm_config.vm.provision "shell", path: get_handler_script_path("dc.users.dsc.ps1"), env: users_env
+                    #vm_config.vm.provision "reload"
+                
+                    # execute tests
+                    execute_tests config: config, 
+                                vm_config: vm_config, 
+                                paths: "#{get_handler_tests_scripts_path}/dc.dsc.*"
+                when "replica"
+                    domain_env = _get_metabox_env(default_properties)
 
-                vm_config.vm.provision "shell", path: get_handler_script_path("dc.dsc.ps1"), env: domain_env
-                vm_config.vm.provision "reload"
+                    default_properties["dsc_check_skip"] = "1"
 
-                default_properties["vagrant_user_name"] = dc_domain_name.split('.')[0] + "\\vagrant"
-                default_properties["vagrant_user_password"] = "vagrant"
-            
-                # provision DC users
-                default_properties.delete("dsc_check_skip")
-                users_env = _get_metabox_env(default_properties)   
+                    # fixing up address to point to the primary DC
+                    host_ip = get_ip_address(environment_name: _get_environment_name, vm_name: _get_vm_name)
+                    dns_ip = get_environment_ip_range(name: _get_environment_name) + ".5"
+                    
+                    ip_settings = "-ip #{host_ip} -dns #{dns_ip}"
+                    vm_config.vm.provision "shell", path: "#{default_vagrant_scripts_path}/metabox.vagrant.core/metabox.fix-second-network.ps1", privileged: false, args: ip_settings
 
-                vm_config.vm.provision "shell", path: get_handler_script_path("dc.users.dsc.ps1"), env: users_env
-                #vm_config.vm.provision "reload"
+                    vm_config.vm.provision "shell", path: get_handler_script_path("dc.replica.dsc.ps1"), env: domain_env
+                    vm_config.vm.provision "reload"
+                else
+                    raise "unsupported type: #{dc_type} - either don't set 'type' property, or use 'main'/'replica'"
 
-            
-                # execute tests
-                execute_tests config: config, 
-                              vm_config: vm_config, 
-                              paths: "#{get_handler_tests_scripts_path}/dc.dsc.*"
+                end
     
             end
 

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_joindc_config.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_joindc_config.rb
@@ -6,8 +6,6 @@ module Metabox
 
         class VagrantJoinDCConfig < VagrantConfigBase
 
-            @config
-
             def initialize
 
             end
@@ -50,7 +48,8 @@ module Metabox
 
                 execute_tests config: config, 
                               vm_config: vm_config, 
-                              paths: "#{get_handler_tests_scripts_path}/dc.join.dsc.*"
+                              paths: "#{get_handler_tests_scripts_path}/dc.join.dsc.*",
+                              env: env
           
             end
            

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_sharepoint_config.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_sharepoint_config.rb
@@ -84,7 +84,8 @@ module Metabox
                 # tests
                 execute_tests config: config, 
                               vm_config: vm_config, 
-                              paths: "#{get_handler_tests_scripts_path}/#{sp_version}.dsc.wfe.*"
+                              paths: "#{get_handler_tests_scripts_path}/#{sp_version}.dsc.wfe.*",
+                              env: env
             end
     
         end

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_sql12_config.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_sql12_config.rb
@@ -49,11 +49,13 @@ module Metabox
                 when "sql12"
                     execute_tests config: config, 
                                 vm_config: vm_config, 
-                                paths: "#{get_handler_tests_scripts_path}/sql12.dsc.*"
+                                paths: "#{get_handler_tests_scripts_path}/sql12.dsc.*",
+                                env: env
                 when "sql16"
                     execute_tests config: config, 
                                 vm_config: vm_config, 
-                                paths: "#{get_handler_tests_scripts_path}/sql16.dsc.*"
+                                paths: "#{get_handler_tests_scripts_path}/sql16.dsc.*",
+                                env: env
                 end
 
                  

--- a/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_win12soe_config.rb
+++ b/src/metabox/lib/services/vagrant/vagrant_configs/vagrant_win12soe_config.rb
@@ -6,8 +6,6 @@ module Metabox
 
         class VagrantWin12SOEConfig < VagrantConfigBase
 
-            @config
-
             def initialize
 
             end

--- a/src/tasks/fileset.rb
+++ b/src/tasks/fileset.rb
@@ -8,4 +8,20 @@ namespace "fileset" do
         )
     end
 
+    desc "Packs one or several fileset resources"
+    task :pack do | task, task_args | 
+        $mb_api.execute_task(
+            task_name: task.name,
+            params: task_args.to_a
+        )
+    end
+
+    desc "Imports fileset resource from existing file"
+    task :import_from_file do | task, task_args | 
+        $mb_api.execute_task(
+            task_name: task.name,
+            params: task_args.to_a
+        )
+    end
+
 end

--- a/src/tasks/metabox.rb
+++ b/src/tasks/metabox.rb
@@ -80,4 +80,14 @@ namespace "metabox" do
         )
     end
 
+    desc "Applies revision to virtual machine"
+    task :apply_revision do | task, task_args | 
+        $mb_api.execute_task(
+            task_name: task.name,
+            params: task_args.to_a
+        )
+    end
+
+    
+
 end

--- a/src/tasks/revision.rb
+++ b/src/tasks/revision.rb
@@ -1,0 +1,11 @@
+namespace "revision" do
+    
+    desc "Applies revision to virtual machine"
+    task :apply do | task, task_args | 
+        $mb_api.execute_task(
+            task_name: task.name,
+            params: task_args.to_a
+        )
+    end
+
+end


### PR DESCRIPTION
As per metabox 0.1.2, https://github.com/SubPointSolutions/metabox/milestone/2?closed=1

Raising early to beta, it's good enough but I am still testing dev VMs. Any major issue should go to 0.1.3

+ Introduce fileset:pack CLI command to pack external file resource #25
+ Introduce fileset:import CLI to import external files #25
+ Simplify customizations/revision usage #22
+ Support offline dotnet4.6 installation for Win2012R2 VMs #20
+ Consistent drive size for Win12/16 VMs #19
+ VisualStudio install should detect .exe automatically #29